### PR TITLE
- fixes a bug where the RSS link would not follow the language

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -53,7 +53,7 @@
             {{- end }}
           {{- end }}
 
-          <a class="button" href="{{ .Site.RSSLink }}">
+          <a class="button" href="{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}">
             <span class="icon"><i class="fa fa-rss"></i></span>
           </a>
 


### PR DESCRIPTION
The RSS link was using a deprecated page variable [see documentation](https://gohugo.io/variables/page/#page-variables) and not taking into account any language translation.
For a multilingual site the button will point to https://domain.com/language/index.xml instead of https://domain.com/index.xml except for the default language which will remain unchanged.